### PR TITLE
Allow comment to notify parent window with postMessage

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -835,6 +835,18 @@ ep_comments.prototype.saveComment = function(data, rep) {
   self.socket.emit('addComment', data, function (commentId, comment){
     comment.commentId = commentId;
 
+    if(window !== window.top) {
+      var data = {
+        event: 'addComment',
+        params: {
+          padId: pad.getPadId(),
+          comment: comment
+        }
+      }
+
+      window.top.postMessage(JSON.stringify(data), '*');
+    }
+
     self.ace.callWithAce(function (ace){
       // console.log('addComment :: ', commentId);
       ace.ace_performSelectionChange(rep.selStart, rep.selEnd, true);


### PR DESCRIPTION
Hooks into the Etherpad comment plugin to deliver a message to the
top-level window. This message only gets passed on the window that made
the comment, if there happen to be multiple views of the pad open.
